### PR TITLE
fix(core): didn't allowed basic tag for text formatting

### DIFF
--- a/resources/views/components/base-alert-box.blade.php
+++ b/resources/views/components/base-alert-box.blade.php
@@ -35,7 +35,16 @@
             </div>
         @endif
         <div class="description font-light">
-            {!! nl2br(htmlspecialchars($helperText)) !!}
+            {!!
+            nl2br(
+                string: strip_tags(
+                    string: $helperText,
+                    allowed_tags: [
+                        'a', 'span', 'p',
+                        'b', 'i', 'u'
+                    ]
+                ))
+            !!}
         </div>
     </div>
 </div>


### PR DESCRIPTION
MR of #14 break the basic text formatting, since we involve with text widget sometimes we need to put some tag to enhacement the widget's behavior. 